### PR TITLE
add nardo-proc package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "localstack": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -16,6 +34,25 @@
         "owner": "nardoring",
         "repo": "localstack-nix",
         "type": "github"
+      }
+    },
+    "nardo-proc": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1700454223,
+        "narHash": "sha256-LCLJnpdC+dKGPDFfLU5Nss6Vzo9axTTYLXrmqC3ntQ8=",
+        "ref": "refs/heads/main",
+        "rev": "a548c2d863c83526b4af7e0952c18c03d39c72b3",
+        "revCount": 1,
+        "type": "git",
+        "url": "file:///home/bh/projects/capstone/nardo-proc"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:///home/bh/projects/capstone/nardo-proc"
       }
     },
     "nixpkgs": {
@@ -36,6 +73,38 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1700204040,
+        "narHash": "sha256-xSVcS5HBYnD3LTer7Y2K8ZQCDCXMa3QUD1MzRjHzuhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c757e9bd77b16ca2e03c89bf8bc9ecb28e0c06ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1699781429,
         "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
         "owner": "NixOS",
@@ -53,7 +122,42 @@
     "root": {
       "inputs": {
         "localstack": "localstack",
-        "nixpkgs": "nixpkgs_2"
+        "nardo-proc": "nardo-proc",
+        "nixpkgs": "nixpkgs_4"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1700273673,
+        "narHash": "sha256-0XD4JvrQiZ9BDFdH3VTwqZVXTYzOfS7DVblvqHBnWgE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "616074a1b2a71bbe44da4cc29a64255aecb8d541",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     localstack.url = "github:nardoring/localstack-nix";
+    nardo-proc.url = "/home/bh/projects/capstone/nardo-proc";
     # rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
@@ -11,6 +12,7 @@
     self,
     nixpkgs,
     localstack,
+    nardo-proc,
     # rust-overlay,
   }: let
     system = "x86_64-linux";
@@ -100,6 +102,7 @@
       localstackImage = localstackImage;
       load-image = load-image;
       nardo = nardo;
+      nardo-proc = nardo-proc.nardo-proc;
       # nardoImage = nardoImage;
     };
   };


### PR DESCRIPTION
### Summary
This pull request introduces the `nardo-proc` package into the existing flake configuration. The addition is part of an ongoing effort to expand the project's capabilities and integrate new functionalities. The `nardo-proc` package, a Rust-based application, interacts with AWS services like SQS and DynamoDB, potentially in a LocalStack environment.

### Changes
- **Flake Configuration Update**: The `flake.nix` file has been modified to include the `nardo-proc` package as a new input and package. This change allows the `nardo-proc` package to be built and utilized within the environment.
- **Context**: The Rust code provided in the `nardo-proc` package (not part of this PR, but for context) includes functionalities for interacting with AWS services. 

  - Sending messages to an SQS queue.
  - Inserting and scanning items in a DynamoDB table.
  - Conditional support for LocalStack, enabling local development and testing.
  - Structured representation and display of request data.

### Technical Details
- **Flake Input Addition**: The `nardo-proc` package is added as an input in the `flake.nix` file, sourced from a local path (`/home/bh/projects/capstone/nardo-proc`).
- **Package Integration**: The package is integrated into the flake's outputs, making it available for build and deployment.

### Usage and Impact
- **Enhanced Functionality**: The integration of `nardo-proc` extends the project's capabilities, particularly in handling AWS-based operations.
- **Development and Testing**: With support for LocalStack, developers can test AWS integrations locally, improving the development workflow.
- **Dependency Management**: By including `nardo-proc` in the flake, its dependencies are managed efficiently, ensuring reproducible builds.
