### PR TITLE
pull localstack-pro image instead

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,10 @@
 
     # Pull Localstack Docker Image
     localstackImage = pkgs.dockerTools.pullImage {
-      imageName = "localstack/localstack";
-      imageDigest = "sha256:31300a9a8a80cfe32aa579b0d0873f130dabcf54d7525803bf9a40f76ee1fa62";
-      sha256 = "0rrd2swcpal7yswx933ig016zarpazmdfgxvzk9v98szc554ssc8";
-      finalImageName = "localstack/localstack";
+      imageName = "localstack/localstack-pro";
+      imageDigest = "sha256:b6bb4d7b1209b47daccd2d58e669b0fb19ace3ecd98572ec6e3e75921768f6f6";
+      sha256 = "sha256-oJlIFsIRtvZSLtABjapc+ZJeJUcDi+xhct/H3o/5pck=";
+      finalImageName = "localstack/localstack-pro";
       finalImageTag = "latest";
     };
 


### PR DESCRIPTION
This pull request updates the Docker image used in our project from `localstack/localstack` to `localstack/localstack-pro`. This change stops Localstack from having to pull both images and allows us to cache the localstack-pro image for faster CI.

## Changes
#### Update to LocalStack Pro Image:

- Modified the `flake.nix` file to pull the `localstack/localstack-pro` image instead of the standard `localstack/localstack` image.
- Updated the `imageDigest` and `sha256` values to match the new pro image.
- Updated the `finalImageName` as `localstack/localstack-pro`.
- Retained the `finalImageTag` as `latest`.

#### File Changes:

- `flake.nix`:
  - Lines 22-30: Changed the Docker image details to use the pro version.