### PR TITLE
Fix row styling issue when table is sorted/filtered

### DIFF
--- a/src/components/ListPage/UseCaseTable.tsx
+++ b/src/components/ListPage/UseCaseTable.tsx
@@ -224,7 +224,7 @@ export default function UseCaseTable() {
               <tr
                 key={row.id}
                 className={`${
-                  table.getRowModel().rows.indexOf(row) % 2 === 0 ? "bg-white" : "bg-veryLightGrey"
+                  table.getRowModel().rows.indexOf(row) % 2 === 0 ? "bg-white" : "bg-lightIndigo"
                 } h-[4.28rem]`}
               >
                 {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
Resolved a bug related to the background color styling in each row. Every other row has a white background or light grey/blueish background. Since this styling was based on the rows index, sorting or filtering the table would result in rows not being styled properly.

Now when rows are styled, the index to be used for the rows styling is based on the rows current position in the table, rather than the rows original index when the table was first rendered.

Also modified the color of the row background to be a bit more visible, and uniform with the rest of the table.
